### PR TITLE
Pass customProperties into the child application.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-angular-cli",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-angular-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Helpers for building single-spa applications which use Angular Cli",
   "main": "lib/single-spa-angular-cli.js",
   "scripts": {

--- a/src/single-spa-angular-cli-platform.ts
+++ b/src/single-spa-angular-cli-platform.ts
@@ -14,11 +14,11 @@ export class SingleSpaAngularCliPlatform {
         return Observable.create((observer: Observer<any>) => {
             if (this.isSingleSpaApp()) {
                 window[this.appName] = {};
-                window[this.appName].mount = () => {
-                    observer.next(this.unmount.bind(this));
+                window[this.appName].mount = (props: any) => {
+                    observer.next({ props, attachUnmount: this.unmount.bind(this) });
                 };
             } else {
-                observer.next(this.unmount.bind(this));
+                observer.next({ props: {}, attachUnmount: this.unmount.bind(this) });
             }
         });
     }

--- a/src/single-spa-angular-cli.js
+++ b/src/single-spa-angular-cli.js
@@ -128,7 +128,7 @@ const mount = (opts, props) => {
     const angularRootEl = document.createElement(opts.selector);
     domEl.appendChild(angularRootEl);
     if (window[opts.selector]) {
-      window[opts.selector].mount();
+      window[opts.selector].mount(props);
       resolve();
     } else {
       console.error(`Cannot mount ${opts.name} because that is not bootstraped`);


### PR DESCRIPTION
Fixes: #3 

Hi @robinComa ,

I had the same needs described in the issue. I decided to create this PR to fix the issue, I´m not sure if it is the right approach, but worth to propose it :)

If you will merge the PR we could implement the use case in the main.ts:

```
singleSpaAngularCliPlatform.mount(appName, Router).subscribe(arg => {
  platformBrowserDynamic().bootstrapModule(AppModule).then( module => {
     const { props, attachUnmount } = arg;
    attachUnmount();
    module.instance.setStore(props.customProps.store);
    module.instance.setGlobalEventDistributor(props.customProps.globalEventDistributor);
  });
});
```