### PR TITLE
Added Customizable MaxBootstrapTimeout

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -57,7 +57,7 @@ const noLoadingApp = (currentApp: string, singleSpa: any) => {
 
 const onNotLoadingApp = (currentApp: string, props: any) => {
     const { singleSpa } = props;
-    const maxBootstrapTime = (props.customProps ? (props.customProps.setBootstrapMaxTime || 3000) : 3000);
+    const maxBootstrapTime = (props.customProps ? (props.customProps.bootstrapMaxTime || 3000) : 3000);
     return new Promise((resolve, reject) => {
         let time = 0;
         const INTERVAL = 100;

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -57,6 +57,7 @@ const noLoadingApp = (currentApp: string, singleSpa: any) => {
 
 const onNotLoadingApp = (currentApp: string, props: any) => {
     const { singleSpa } = props;
+    const maxBootstrapTime = (props.customProps ? (props.customProps.setBootstrapMaxTime || 3000) : 3000);
     return new Promise((resolve, reject) => {
         let time = 0;
         const INTERVAL = 100;
@@ -66,7 +67,6 @@ const onNotLoadingApp = (currentApp: string, props: any) => {
                 clearInterval(interval);
                 resolve();
             }
-            const maxBootstrapTime = (props.customProps ? (props.customProps.setBootstrapMaxTime || 3000) : 3000);
             if (time >= maxBootstrapTime) {
                 clearInterval(interval);
                 reject(`The application could not be loaded because another is still loading more than ${time} milliseconds`);

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -57,7 +57,7 @@ const noLoadingApp = (currentApp: string, singleSpa: any) => {
 
 const onNotLoadingApp = (currentApp: string, props: any) => {
     const { singleSpa } = props;
-    const maxBootstrapTime = (props.customProps ? (props.customProps.bootstrapMaxTime || 3000) : 3000);
+    const bootstrapMaxTime = props.bootstrapMaxTime || 3000;
     return new Promise((resolve, reject) => {
         let time = 0;
         const INTERVAL = 100;
@@ -67,7 +67,7 @@ const onNotLoadingApp = (currentApp: string, props: any) => {
                 clearInterval(interval);
                 resolve();
             }
-            if (time >= maxBootstrapTime) {
+            if (time >= bootstrapMaxTime) {
                 clearInterval(interval);
                 reject(`The application could not be loaded because another is still loading more than ${time} milliseconds`);
             }

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -66,7 +66,8 @@ const onNotLoadingApp = (currentApp: string, props: any) => {
                 clearInterval(interval);
                 resolve();
             }
-            if (time >= (props.customProps.bootstrapMaxTime || 3000)) {
+            const maxBootstrapTime = (props.customProps ? (props.customProps.setBootstrapMaxTime || 3000) : 3000);
+            if (time >= maxBootstrapTime) {
                 clearInterval(interval);
                 reject(`The application could not be loaded because another is still loading more than ${time} milliseconds`);
             }

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -4,7 +4,7 @@ declare const window: any;
 window.singleSpaAngularCli = window.singleSpaAngularCli || {};
 
 const xmlToAssets = (xml: string): { styles: string[], scripts: string[] } => {
-    var dom = document.createElement('html');
+    const dom = document.createElement('html');
     dom.innerHTML = xml;
     const linksEls = dom.querySelectorAll('link[rel="stylesheet"]');
     const scriptsEls = dom.querySelectorAll('script[type="text/javascript"]');
@@ -12,7 +12,7 @@ const xmlToAssets = (xml: string): { styles: string[], scripts: string[] } => {
         styles: Array.from(linksEls).map(el => el.getAttribute('href')),
         scripts: Array.from(scriptsEls).map(el => el.getAttribute('src')).filter(src => !src.match(/zone\.js/))
     };
-}
+};
 
 const transformOptsWithAssets = (opts: Options): Promise<null> => {
     const url = `${opts.baseHref}/index.html`;
@@ -55,7 +55,8 @@ const noLoadingApp = (currentApp: string, singleSpa: any) => {
     return currentIndex <= firstInMountingIndex;
 };
 
-const onNotLoadingApp = (currentApp: string, singleSpa: any) => {
+const onNotLoadingApp = (currentApp: string, props: any) => {
+    const { singleSpa } = props;
     return new Promise((resolve, reject) => {
         let time = 0;
         const INTERVAL = 100;
@@ -65,7 +66,7 @@ const onNotLoadingApp = (currentApp: string, singleSpa: any) => {
                 clearInterval(interval);
                 resolve();
             }
-            if (time >= 3000) {
+            if (time >= (props.customProps.bootstrapMaxTime || 3000)) {
                 clearInterval(interval);
                 reject(`The application could not be loaded because another is still loading more than ${time} milliseconds`);
             }
@@ -83,15 +84,15 @@ const loadAllAssets = (opts: Options) => {
             const stylesPromise = opts.styles.reduce(
                 (prev: Promise<undefined>, fileName: string) => prev.then(loadLinkTag(`${opts.baseHref}/${fileName}`)),
                 Promise.resolve(undefined)
-            )
+            );
             Promise.all([scriptsPromise, stylesPromise]).then(resolve, reject);
         }, reject);
     });
 };
 
 const hashCode = (str: string): string => {
-    var hash = 0;
-    if (str.length == 0) return hash.toString();
+    let hash = 0;
+    if (str.length === 0) return hash.toString();
     for (let i = 0; i < str.length; i++) {
         hash = (hash << 5) - hash + str.charCodeAt(i);
         hash = hash & hash;
@@ -147,9 +148,8 @@ const unloadTag = (url: string) => {
 
 const bootstrap = (opts: Options, props: any) => {
     window.singleSpaAngularCli.isSingleSpa = true;
-    const { singleSpa } = props
     return new Promise((resolve, reject) => {
-        onNotLoadingApp(opts.name, singleSpa).then(() => {
+        onNotLoadingApp(opts.name, props).then(() => {
             loadAllAssets(opts).then(resolve, reject);
         }, reject);
     });
@@ -169,7 +169,7 @@ const mount = (opts: Options, props: any) => {
 };
 
 const unmount = (opts: Options, props: any) => {
-    const { singleSpa: { unloadApplication, getAppNames } } = props
+    const { singleSpa: { unloadApplication, getAppNames } } = props;
     return new Promise((resolve, reject) => {
         if (window.singleSpaAngularCli[opts.name]) {
             window.singleSpaAngularCli[opts.name].unmount();


### PR DESCRIPTION
Edited `onNotLoadingApp()` function to look for singleSpa props.customProps.bootstrapMaxTime before defaulting to a 3000ms timeout. This can be set when initializing an app with single-spa as follows (the customProps object is the last object in the single-spa `registerApplication()` function):
```
registerApplication(
  application.name,
  (() => {
    const lifecycles = loader({
      name: application.name,
      selector: application.selector,
      baseHref: application.baseHref,
    });
    return {
      bootstrap: [lifecycles.bootstrap],
      mount: [lifecycles.mount],
      unmount: [lifecycles.unmount],
      unload: [lifecycles.unload],
    };
  })(),
  router.matchRoute(application.matchRoute, application.isDefaultApp),
  {
    bootstrapMaxTime: 6000
  }
);
```
Also added some missing semicolons, changed `==` to `===`, and changed `var` to `let` and `const` in several places in the typescript.