### PR TITLE
Added Option to Prevent Unmount

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -177,7 +177,7 @@ const unmount = (opts: Options, props: any) => {
     const { singleSpa: { unloadApplication, getAppNames } } = props
     return new Promise((resolve, reject) => {
         if (window.singleSpaAngularCli[opts.name]) {
-            if (props.customProps && props.customProps.preventUnmount) {
+            if (props.preventUnmount) {
                 resolve();
             } else {
                 window.singleSpaAngularCli[opts.name].unmount();

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -156,14 +156,19 @@ const bootstrap = (opts: Options, props: any) => {
 };
 
 const mount = (opts: Options, props: any) => {
+    const { singleSpa } = props;
     return new Promise((resolve, reject) => {
-        getContainerEl(opts);
-        if (window.singleSpaAngularCli[opts.name]) {
-            window.singleSpaAngularCli[opts.name].mount(props);
-            resolve();
+        if (singleSpa.getAppStatus(opts.name) !== singleSpa.MOUNTED) {
+            getContainerEl(opts);
+            if (window.singleSpaAngularCli[opts.name]) {
+                window.singleSpaAngularCli[opts.name].mount(props);
+                resolve();
+            } else {
+                console.error(`Cannot mount ${opts.name} because that is not bootstraped`);
+                reject();
+            }
         } else {
-            console.error(`Cannot mount ${opts.name} because that is not bootstraped`);
-            reject();
+            resolve();
         }
     });
 };

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -172,13 +172,17 @@ const unmount = (opts: Options, props: any) => {
     const { singleSpa: { unloadApplication, getAppNames } } = props
     return new Promise((resolve, reject) => {
         if (window.singleSpaAngularCli[opts.name]) {
-            window.singleSpaAngularCli[opts.name].unmount();
-            getContainerEl(opts).remove();
-            if (getAppNames().indexOf(opts.name) !== -1) {
-                unloadApplication(opts.name, { waitForUnmount: true });
+            if (props.customProps && props.customProps.preventUnmount) {
                 resolve();
             } else {
-                reject(`Cannot unmount ${opts.name} because that ${opts.name} is not part of the decalred applications : ${getAppNames()}`);
+                window.singleSpaAngularCli[opts.name].unmount();
+                getContainerEl(opts).remove();
+                if (getAppNames().indexOf(opts.name) !== -1) {
+                    unloadApplication(opts.name, {waitForUnmount: true});
+                    resolve();
+                } else {
+                    reject(`Cannot unmount ${opts.name} because that ${opts.name} is not part of the decalred applications : ${getAppNames()}`);
+                }
             }
         } else {
             reject(`Cannot unmount ${opts.name} because that is not bootstraped`);


### PR DESCRIPTION
Added an option to intentionally prevent app unmounting by specifying a variable preventUnmount in the single spa props.customProps. An example of this:
```
registerApplication(
  application.name,
  (() => {
    const lifecycles = loader({
      name: application.name,
      selector: application.selector,
      baseHref: application.baseHref,
    });
    return {
      bootstrap: [lifecycles.bootstrap],
      mount: [lifecycles.mount],
      unmount: [lifecycles.unmount],
      unload: [lifecycles.unload],
    };
  })(),
  router.matchRoute(application.matchRoute, application.isDefaultApp),
  {
    preventUnmount: true
  }
);
```
This is useful because in some cases, the child apps make API calls and/or retrieve data, which can take some time. If we unmount the child apps, they have to make the API calls again next time they mount, repeating that initial wasted time. If we leave the child apps mounted even after navigating off of them, once we navigate back to them we don't necessarily need to retrieve the data again.