### PR TITLE
Deprecating this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+# This project is deprecated. Use [single-spa-angular]() instead, which supports Angular CLI and Angular 7+
+
 # single-spa-angular-cli
+
 Helpers for building [single-spa](https://github.com/CanopyTax/single-spa) applications which use Angular Cli.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This project is deprecated. Use [single-spa-angular]() instead, which supports Angular CLI and Angular 7+
+# This project is deprecated. Use [single-spa-angular](https://github.com/CanopyTax/single-spa-angular/) instead, which supports Angular CLI and Angular 7+
 
 # single-spa-angular-cli
 


### PR DESCRIPTION
single-spa-angular@3.0.0 supports Angular 7 and Angular 8, while also providing bug fixes and better support for older versions of Angular.